### PR TITLE
Enhancement: Support for generating rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dkms.conf
 
 .cache
 build
+include/config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(isosm3sum)
 
 set(PROJECT_NAME "isosm3sum")
-set(PROJECT_VERSION "0.8.0")
+set(PROJECT_VERSION "0.9.0")
 
 set(CMAKE_C_FLAGS
     "${CMAKE_C_FLAGS} -std=gnu11 -Wall -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE=1 -D_LARGEFILE64_SOURCE=1 -fPIC"
@@ -13,6 +13,14 @@ configure_file(include/config.h.in ${PROJECT_SOURCE_DIR}/include/config.h)
 
 set(CMAKE_SYSTEM_PREFIX_PATH "/usr")
 set(INCLUDEDIR "include")
+
+if(NOT DEFINED LIBDIR)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "sw_64")
+        set(LIBDIR "lib")
+    else()
+        set(LIBDIR "lib64")
+    endif()
+endif()
 
 option(PYTHON_EXECUTABLE "Path to the Python executable" "")
 if(NOT PYTHON_EXECUTABLE)
@@ -74,3 +82,59 @@ install(
         GROUP_EXECUTE
         WORLD_READ
         WORLD_EXECUTE)
+
+install(
+    TARGETS checkisosm3-static implantisosm3-static
+    DESTINATION ${LIBDIR}
+    PERMISSIONS
+        OWNER_READ
+        OWNER_WRITE
+        OWNER_EXECUTE
+        GROUP_READ
+        GROUP_EXECUTE
+        WORLD_READ
+        WORLD_EXECUTE
+    ARCHIVE DESTINATION ${LIBDIR})
+
+install(
+    DIRECTORY include/
+    DESTINATION ${INCLUDEDIR}
+    FILES_MATCHING
+    PATTERN "lib*.h")
+
+configure_file(src/isosm3sum.pc.in ${CMAKE_BINARY_DIR}/isosm3sum.pc @ONLY)
+install(
+    FILES ${CMAKE_BINARY_DIR}/isosm3sum.pc
+    DESTINATION ${LIBDIR}/pkgconfig
+    PERMISSIONS
+        OWNER_READ
+        OWNER_WRITE
+        OWNER_EXECUTE
+        GROUP_READ
+        GROUP_EXECUTE
+        WORLD_READ
+        WORLD_EXECUTE)
+
+add_test(NAME testpyisosm3sum-large COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/testpyisosm3sum.py 200)
+add_test(NAME testpyisosm3sum-small COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/testpyisosm3sum.py)
+set_tests_properties(
+    testpyisosm3sum-large testpyisosm3sum-small
+    PROPERTIES ENVIRONMENT
+               "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${LD_LIBRARY_PATH};PYTHONPATH=${CMAKE_BINARY_DIR}:${PYTHONPATH}")
+enable_testing()
+
+add_custom_target(
+    archive
+    COMMAND git archive --format=tar --prefix=${PROJECT_NAME}-${PROJECT_VERSION}/ HEAD | bzip2 >
+            ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}.tar.bz2
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Creating archive"
+    VERBATIM)
+
+configure_file(misc/isosm3sum.spec.in ${CMAKE_BINARY_DIR}/isosm3sum.spec)
+add_custom_target(
+    srpm
+    COMMAND make archive && bash ${PROJECT_SOURCE_DIR}/scripts/generate-srpm.sh
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Creating source rpm"
+    VERBATIM)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # isosm3sum
+
 Utilities for working with sm3sum implanted in ISO images
+
+isosm3sum provides a way of making use of the ISO9660 application data
+area to store sm3sum data about the iso. This allows you to check the
+iso given nothing more than the iso itself.
+
+<span style="color:red">Software implementation based on </span>**[isomd5sum](https://github.com/rhinstaller/isomd5sum).**
+
+## Build
+
+Use the following command to compile:
+
+```bash
+cmake -G 'Unix Makefiles' -B build .
+make -j$(nproc) -C build
+```
+
+## Installation
+
+Use the following command to install the compilation result into /path/to/you/dir:
+
+```bash
+make -C build DESTDIR=/path/to/you/dir
+```
+
+## Build rpm
+
+Create the src.rpm with the following command:
+
+```bash
+make srpm -C build
+```
+
+You will see from the screen output, the path where the src.rpm file is stored:
+
+```log
+Source RPM: /path/to/isosm3sum/build/SRPMS/isosm3sum-0.9.0-1.src.rpm
+```
+
+Now you can use the rpmbuild command to build out the rpm packages:
+
+```bash
+rpmbuild --rebuild /path/to/isosm3sum/build/SRPMS/isosm3sum-0.9.0-1.src.rpm
+```
+
+If you want to execute unit tests during the build process, add the parameter "--with tests":
+
+```bash
+rpmbuild --rebuild /path/to/isosm3sum/build/SRPMS/isosm3sum-0.9.0-1.src.rpm --with tests
+```

--- a/include/config.h
+++ b/include/config.h
@@ -1,7 +1,0 @@
-#ifndef CONFIG_H
-#define CONFIG_H
-
-#define PROJECT_NAME "isosm3sum"
-#define PROJECT_VERSION "0.8.0"
-
-#endif // CONFIG_H

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -28,7 +28,7 @@ int getpagesize()
 /* The length of the SM3 digital digest is 512 bits, 64 bytes */
 #define HASH_SIZE 64
 /* Length in characters of string used for fragment sm3sum checking */
-#define FRAGMENT_SUM_SIZE 60UL
+#define FRAGMENT_SUM_SIZE 120UL
 /* FRAGMENT_COUNT must be an integral divisor or FRAGMENT_SUM_SIZE */
 /* 60 => 2, 3, 4, 5, 6, 10, 12, 15, 20, or 30 */
 #define FRAGMENT_COUNT 20UL

--- a/misc/isosm3sum.spec.in
+++ b/misc/isosm3sum.spec.in
@@ -1,0 +1,69 @@
+%bcond_with     tests
+
+Name:           isosm3sum
+Version:        @PROJECT_VERSION@
+Release:        1%{?dist}
+Summary:        Utilities for working with sm3sum implanted in ISO images
+
+License:        GPL-2.0
+URL:            https://github.com/reganhe-x/%{name}
+Source0:        @PROJECT_NAME@-@PROJECT_VERSION@.tar.bz2
+
+BuildRequires:  cmake make gcc-c++ popt-devel pkgconfig(systemd)
+%if %{with tests}
+BuildRequires:  genisoimage
+%endif
+
+%description
+%{name} provides a way of making use of the ISO9660 application data
+area to store sm3sum data about the iso. This allows you to check the
+iso given nothing more than the iso itself.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+Development files for %{name}.
+
+%package -n     python3-py%{name}
+Summary:        Python bindings for %{name}
+BuildRequires:  python3-devel
+
+%description -n python3-py%{name}
+Python bindings for %{name}.
+
+%prep
+%autosetup
+
+%build
+%cmake -G 'Unix Makefiles' -B build .
+%make_build -C build
+
+%if %{with tests}
+%check
+%make_build -C build test
+%endif
+
+%install
+%make_install -C build
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/checkisosm3
+%{_bindir}/implantisosm3
+
+%files devel
+%{_includedir}/libcheckisosm3.h
+%{_includedir}/libimplantisosm3.h
+%{_libdir}/libcheckisosm3-static.a
+%{_libdir}/libimplantisosm3-static.a
+%{_libdir}/pkgconfig/%{name}.pc
+
+%files -n python3-pyisosm3sum
+%license LICENSE
+%doc README.md
+%{python3_sitearch}/pyisosm3sum.so
+
+%changelog

--- a/scripts/generate-srpm.sh
+++ b/scripts/generate-srpm.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/bash
+#shellcheck shell=bash
+
+if ! ps -p $PPID -o cmd= | grep -qE '^make '; then
+    echo >&2 "ERROR: This script should be called from Makefile"
+    exit 1
+fi
+
+REQUIRES_CMD=(
+    "rpmbuild"
+    "rpmdev-setuptree"
+    "pushd"
+    "popd"
+    "rpmspec"
+)
+
+for cmd in "${REQUIRES_CMD[@]}"; do
+    if ! command -v "${cmd}" &>/dev/null; then
+        echo "ERROR: ${cmd} not found"
+        exit 1
+    fi
+done
+
+SPEC_FILE="./isosm3sum.spec"
+if [[ ! -f "${SPEC_FILE}" ]]; then
+    echo "ERROR: ${SPEC_FILE} not found"
+    exit 1
+fi
+
+SOURCE0="$(rpmspec -P "${SPEC_FILE}" -D 'dist %{nil}' -q --srpm --qf="%{name}-%{version}.tar.bz2")"
+if [[ ! -f "${SOURCE0:?}" ]]; then
+    echo "ERROR: ${SOURCE0} not found"
+    exit 1
+fi
+
+RPMBUILD_TOPDIR="$(realpath .)"
+rpmdev-setuptree -D "_topdir ${RPMBUILD_TOPDIR}"
+if [[ ! -d "${RPMBUILD_TOPDIR:?}" ]]; then
+    echo "ERROR: ${RPMBUILD_TOPDIR} not found"
+    exit 1
+fi
+
+SRPM_NAME="${RPMBUILD_TOPDIR}/SRPMS/$(rpmspec -P "${SPEC_FILE}" -D 'dist %{nil}' \
+    -q --srpm --qf="%{name}-%{version}-%{release}.src.rpm")"
+rpmbuild -bs --target noarch "${SPEC_FILE}" --nodeps -D "dist %{nil}" \
+    -D "_topdir ${RPMBUILD_TOPDIR}" \
+    -D "_sourcedir ${RPMBUILD_TOPDIR}" &>/dev/null || {
+    echo "rpmbuild failed."
+    exit 1
+}
+
+if [[ ! -f "${SRPM_NAME:?}" ]]; then
+    echo "ERROR: ${SRPM_NAME} not found"
+    exit 1
+fi
+
+echo "Source RPM: ${SRPM_NAME}"

--- a/src/isosm3sum.pc.in
+++ b/src/isosm3sum.pc.in
@@ -1,0 +1,9 @@
+includedir=/usr/@INCLUDEDIR@
+libdir=/usr/@LIBDIR@
+
+Name: isosm3sum
+Description: Utilities for working with sm3sum implanted in ISO images
+URL: https://github.com/reganhe-x/isosm3sum
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir}

--- a/test/testpyisosm3sum.py
+++ b/test/testpyisosm3sum.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import pyisosm3sum
+
+
+# Pass in the rc, the expected value and the pass_all state
+# Returns a PASS/FAIL string and updates pass_all if it fails
+def pass_fail(rc, pass_value, pass_all):
+    if rc == pass_value:
+        return ("PASS", pass_all)
+    else:
+        return ("FAIL", False)
+
+
+try:
+    iso_size = int(sys.argv[1])
+except (IndexError, ValueError):
+    iso_size = 0
+
+try:
+    # Python 3
+    catch_error = FileNotFoundError
+except NameError:
+    # Python 2
+    catch_error = OSError
+
+# create iso file using a clean directory
+with tempfile.TemporaryDirectory(prefix="isosm3test-") as tmpdir:
+    # Write temporary data to iso test dir
+    with open(tmpdir + "/TEST-DATA", "w") as f:
+        # Write more data base on cmdline arg
+        for x in range(0, iso_size):
+            f.write("A" * 1024)
+
+    try:
+        subprocess.check_call(["mkisofs", "-quiet", "-o", "testiso.iso", tmpdir])
+    except catch_error:
+        subprocess.check_call(["genisoimage", "-quiet", "-o", "testiso.iso", tmpdir])
+
+    if not os.path.exists("testiso.iso"):
+        print("Error creating iso")
+        sys.exit(1)
+
+# implant it
+(rstr, pass_all) = pass_fail(pyisosm3sum.implantisosm3sum("testiso.iso", 1, 0), 0, True)
+print("Implanting -> %s" % rstr)
+
+# do it again without forcing, should get error
+(rstr, pass_all) = pass_fail(
+    pyisosm3sum.implantisosm3sum("testiso.iso", 1, 0), -1, pass_all
+)
+print("Implanting again w/o forcing -> %s" % rstr)
+
+# do it again with forcing, should work
+(rstr, pass_all) = pass_fail(
+    pyisosm3sum.implantisosm3sum("testiso.iso", 1, 1), 0, pass_all
+)
+print("Implanting again forcing -> %s" % rstr)
+
+# check it
+(rstr, pass_all) = pass_fail(pyisosm3sum.checkisosm3sum("testiso.iso"), 1, pass_all)
+print("Checking -> %s" % rstr)
+
+
+def callback(offset, total):
+    print("    %s - %s" % (offset, total))
+
+
+print("Run with callback, prints offset and total")
+(rstr, pass_all) = pass_fail(
+    pyisosm3sum.checkisosm3sum("testiso.iso", callback), 1, pass_all
+)
+print(rstr)
+
+
+def callback_abort(offset, total):
+    print("    %s - %s" % (offset, total))
+    if offset > 100000:
+        return True
+    return False
+
+
+print("Run with callback and abort after offset of 100000")
+(rstr, pass_all) = pass_fail(
+    pyisosm3sum.checkisosm3sum("testiso.iso", callback_abort), 2, pass_all
+)
+print(rstr)
+
+# clean up
+os.unlink("testiso.iso")
+
+if pass_all:
+    exit(0)
+else:
+    exit(1)


### PR DESCRIPTION
- Fixes: fragment sum Displays SM3SUM with a character instead of a number
- Update README.md
- Add spec file for rpmbuild
- Compile target to add packaging and generate srpm
- Remove the config.h file, which should be automatically generated at compile time
- Adding Compilation Tests